### PR TITLE
Feature/allow init options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 
 export interface IConfigurationStore {
-  init(): Promise<IConfigurationStore>
+  init<TOption>(options?: TOption): Promise<IConfigurationStore>
   setGlobalData<T>(key: string, value: T): Promise<T>
   getGlobalData<T>(key: string, defaultValue?: T): Promise<T>
   setUserData<T>(key: string, value: T): Promise<T>
@@ -12,7 +12,7 @@ export abstract class BaseConfigurationStore implements IConfigurationStore {
 
   protected abstract setData<T>(settingsPath: string, value: T): Promise<T>;
   protected abstract getData<T>(settingsPath: string, defaultValue?: T): Promise<T>;
-  public abstract init(): Promise<IConfigurationStore>;
+  public abstract init<TOption>(options?: TOption): Promise<IConfigurationStore>;
 
   private getGlobalSettingsPath(key: string): string {
     return `${this.globalPath}${key}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fvlab/configurationstore",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Models, interfaces and base classes to support basic key-value configuration storage at global and user levels",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Add ability for options to be passed into the `init()` method so underlying implementers can take advantage of it.